### PR TITLE
updated plot with sharex=True and wrap with a mode 'constant'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.vscode/PythonImportHelper-v2-Completion.json

--- a/doc/examples/plot_color_code.py
+++ b/doc/examples/plot_color_code.py
@@ -40,7 +40,7 @@ u, v = pyimof.solvers.ilk(I0, I1)
 # --- Display it with different colormaps
 
 fig = plt.figure(figsize=((9, 10)))
-ax_arr = fig.subplots(3, 2, True, True)
+ax_arr = fig.subplots(3, 2, sharex=True, sharey=True)
 fig.tight_layout()
 
 ax0, ax1 = ax_arr[0, :]

--- a/doc/examples/plot_quiver.py
+++ b/doc/examples/plot_quiver.py
@@ -24,7 +24,7 @@ norm = np.sqrt(u*u + v*v)
 # --- Display it with different options
 
 fig = plt.figure(figsize=((9, 7)))
-ax0, ax1, ax2, ax3 = fig.subplots(2, 2, True, True).ravel()
+ax0, ax1, ax2, ax3 = fig.subplots(2, 2, sharex=True, sharey=True).ravel()
 fig.tight_layout()
 
 ax0.imshow(I0, cmap='gray')

--- a/doc/examples/plot_registration.py
+++ b/doc/examples/plot_registration.py
@@ -36,7 +36,7 @@ nl, nc = I0.shape
 
 y, x = np.meshgrid(np.arange(nl), np.arange(nc), indexing='ij')
 
-wI1 = warp(I1, np.array([y+v, x+u]), mode='nearest')
+wI1 = warp(I1, np.array([y+v, x+u]), mode='constant')
 
 # build an RGB image with the unregistered sequence
 seq_im = np.zeros((nl, nc, 3))
@@ -59,7 +59,7 @@ target_im[..., 2] = I0
 # --- Show the result
 
 fig = plt.figure(figsize=(15, 4))
-ax0, ax1, ax2 = fig.subplots(1, 3, True)
+ax0, ax1, ax2 = fig.subplots(1, 3)
 
 ax0.imshow(seq_im)
 ax0.set_title("Unregistered sequence")

--- a/pyimof/solvers.py
+++ b/pyimof/solvers.py
@@ -74,7 +74,7 @@ def _tvl1(I0, I1, u0, v0, dt, lambda_, tau, nwarp, niter, tol, prefilter):
             u = ndi.filters.median_filter(u, 3)
             v = ndi.filters.median_filter(v, 3)
 
-        wI1 = warp(I1, np.array([y+v, x+u]), mode='nearest')
+        wI1 = warp(I1, np.array([y+v, x+u]), mode='constant')
         Iy, Ix = np.gradient(wI1)
         NI = Ix*Ix + Iy*Iy
         NI[NI == 0] = 1
@@ -238,7 +238,7 @@ def _ilk(I0, I1, u0, v0, rad, nwarp, gaussian, prefilter):
             u = ndi.filters.median_filter(u, 3)
             v = ndi.filters.median_filter(v, 3)
 
-        wI1 = warp(I1, np.array([y+v, x+u]), mode='nearest')
+        wI1 = warp(I1, np.array([y+v, x+u]), mode='constant')
         Iy, Ix = np.gradient(wI1)
         It = wI1 - I0 - u*Ix - v*Iy
 

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     ],
     install_requires=REQUIRES,
     extras_require=EXTRA_REQUIRES,
-    python_requires='>=3.5',
+    python_requires='>=3.7',
     zip_safe=False,
     package_data={'': ["data/*/*.png"]},
     packages=find_packages(exclude=['test', 'doc'])


### PR DESCRIPTION
new matplotlib requires explicit `sharex=True` and `sharey=True`
scikit-image wrap changed to `constant` (`nearest` does not exist anymore)